### PR TITLE
Add major version pinning

### DIFF
--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -2,20 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.74.0"
+  version     = "3.74.2"
+  constraints = "~> 3.47"
   hashes = [
-    "h1:y9b9LluBQGrZHURGY1Xmrhb+zQ6qRit3oqFSLijkGe0=",
-    "zh:00767509c13c0d1c7ad6af702c6942e6572aa6d529b40a00baacc0e73faafea2",
-    "zh:03aafdc903ad49c2eda03889f927f44212674c50e475a9c6298850381319eec2",
-    "zh:2de8a6a97b180f909d652f215125aa4683e99db15fcf3b28d62e3d542f875ed6",
-    "zh:3ac29ebc3af99028f4230a79f56606a0c2954b68767bd749b921a76eb4f3bd30",
-    "zh:50add2e2d118a15a644360eabc5a34cec59f2560b491f8fabf9c52ab83ca7b09",
-    "zh:85dd8e81910ab79f841a4a595fdd8ac358fbfe460956144afb0be3d81f91fe10",
-    "zh:895de83d0f0941fde31bfc53fa6b1ea276901f006bec221bbdee4771a04f3693",
-    "zh:a15c9724aac52d1ba5001d2d83e42843099b52b1638ea29d84e20be0f45fa4f1",
-    "zh:c982a64463bd73e9bff2589de214b1de0a571438d9015001f9eae45cfc3a2559",
-    "zh:e9ef973c18078324e43213ea1252c12b9441e566bf054ddfdbff5dd62f3035d9",
-    "zh:f297e705b0f339c8baa27ae70db5df9aa6578adfe1ea3d2ba8edc186512464eb",
+    "h1:gyAOih3vXIcMuixQQSbUZWS2cRDcYmEwOc01/ATpuoo=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
   ]
 }
 
@@ -34,25 +35,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
     "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
     "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
     "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.2.0"
-  hashes = [
-    "h1:V1XoXkVwM+Bg73BNtbMxScjTcty2jbRZzgSdHrYxQ+4=",
-    "zh:094c3cfae140fbb70fb0e272b1df833b4d7467c6c819fbf59a3e8ac0922f95b6",
-    "zh:15c3906abbc1cd03a72afd02bda9caeeb5f6ca421292c32ddeb2acd7a3488669",
-    "zh:388c14bceeb1593bb16cadedc8f5ad7d41d398197db049dc0871bc847aa61083",
-    "zh:5696772136b6763faade0cc065fafc2bf06493021b943826be0144790fae514a",
-    "zh:6427c693b1b750644d5b633395e54617dc36ae717a531a5cde8cb0246b6593ca",
-    "zh:7196d9845eeffa3158f5e3067bf8b7ad489490aa26d29e2da1ad4c8924463469",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8850d3ce9e5f5776b9349890ce4e2c4056defe16ed741dc845045942a6d9e025",
-    "zh:a2c6fc6cf087b35ebd6b6f20272ed32d4217ea9936c1dd630baa46d86718a455",
-    "zh:ac709be4ea5c9a6e1ab80e864d24cd9f8e6aaea29fb5dbe1de0897e2e86c3c17",
-    "zh:dcf806f044801fae5b21ae2754dc3c19c68e458d4584965752ce49be75305ff5",
-    "zh:f875b34be86c3439899828978638ef7e2d41a9e5e32397858a0c31daeaa1abc2",
   ]
 }
 
@@ -75,7 +57,8 @@ provider "registry.terraform.io/hashicorp/http" {
 }
 
 provider "registry.terraform.io/ojford/wireguard" {
-  version = "0.1.3"
+  version     = "0.1.3"
+  constraints = "~> 0.1.3"
   hashes = [
     "h1:tLwoMLiWsjpvS+83Ee270mj1gf7ivZPYCghWpBD4VqE=",
     "zh:00b01809ab0336f2643a1e2f97c85d5fc4539fff5561c24ab4d195f6d4e5d4c6",

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -1,6 +1,9 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.47 |
+| <a name="requirement_wireguard"></a> [wireguard](#requirement\_wireguard) | ~> 0.1.3 |
 
 ## Providers
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -6,8 +6,13 @@ provider "wireguard" {}
 
 terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.47"
+    }
     wireguard = {
-      source = "OJFord/wireguard"
+      source  = "OJFord/wireguard"
+      version = "~> 0.1.3"
     }
   }
 }

--- a/terraform/do/.terraform.lock.hcl
+++ b/terraform/do/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/digitalocean/digitalocean" {
-  version = "2.17.1"
+  version     = "2.17.1"
+  constraints = "~> 2.17.0"
   hashes = [
     "h1:D+DJxMtHwinDoBkMGAsKOslON4KdrkXI/kpuNPExDdE=",
     "zh:08a5eae6ead1b9b066079af9c4efe5142e632be6ce4f0b52ab07f50e3b323523",
@@ -41,25 +42,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.2.0"
-  hashes = [
-    "h1:V1XoXkVwM+Bg73BNtbMxScjTcty2jbRZzgSdHrYxQ+4=",
-    "zh:094c3cfae140fbb70fb0e272b1df833b4d7467c6c819fbf59a3e8ac0922f95b6",
-    "zh:15c3906abbc1cd03a72afd02bda9caeeb5f6ca421292c32ddeb2acd7a3488669",
-    "zh:388c14bceeb1593bb16cadedc8f5ad7d41d398197db049dc0871bc847aa61083",
-    "zh:5696772136b6763faade0cc065fafc2bf06493021b943826be0144790fae514a",
-    "zh:6427c693b1b750644d5b633395e54617dc36ae717a531a5cde8cb0246b6593ca",
-    "zh:7196d9845eeffa3158f5e3067bf8b7ad489490aa26d29e2da1ad4c8924463469",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8850d3ce9e5f5776b9349890ce4e2c4056defe16ed741dc845045942a6d9e025",
-    "zh:a2c6fc6cf087b35ebd6b6f20272ed32d4217ea9936c1dd630baa46d86718a455",
-    "zh:ac709be4ea5c9a6e1ab80e864d24cd9f8e6aaea29fb5dbe1de0897e2e86c3c17",
-    "zh:dcf806f044801fae5b21ae2754dc3c19c68e458d4584965752ce49be75305ff5",
-    "zh:f875b34be86c3439899828978638ef7e2d41a9e5e32397858a0c31daeaa1abc2",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/http" {
   version = "2.1.0"
   hashes = [
@@ -79,7 +61,8 @@ provider "registry.terraform.io/hashicorp/http" {
 }
 
 provider "registry.terraform.io/ojford/wireguard" {
-  version = "0.1.3"
+  version     = "0.1.3"
+  constraints = "~> 0.1.3"
   hashes = [
     "h1:tLwoMLiWsjpvS+83Ee270mj1gf7ivZPYCghWpBD4VqE=",
     "zh:00b01809ab0336f2643a1e2f97c85d5fc4539fff5561c24ab4d195f6d4e5d4c6",

--- a/terraform/do/README.md
+++ b/terraform/do/README.md
@@ -1,15 +1,18 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.17.0 |
+| <a name="requirement_wireguard"></a> [wireguard](#requirement\_wireguard) | ~> 0.1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.2.0 |
-| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | 2.17.1 |
-| <a name="provider_http"></a> [http](#provider\_http) | 2.1.0 |
-| <a name="provider_wireguard"></a> [wireguard](#provider\_wireguard) | 0.1.3 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_digitalocean"></a> [digitalocean](#provider\_digitalocean) | ~> 2.17.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
+| <a name="provider_wireguard"></a> [wireguard](#provider\_wireguard) | ~> 0.1.3 |
 
 ## Modules
 

--- a/terraform/do/main.tf
+++ b/terraform/do/main.tf
@@ -7,10 +7,12 @@ provider "wireguard" {}
 terraform {
   required_providers {
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.17.0"
     }
     wireguard = {
-      source = "OJFord/wireguard"
+      source  = "OJFord/wireguard"
+      version = "~> 0.1.3"
     }
   }
 }

--- a/terraform/linode/.terraform.lock.hcl
+++ b/terraform/linode/.terraform.lock.hcl
@@ -1,0 +1,80 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.1.0"
+  hashes = [
+    "h1:GYoVrTtiSAE3AlP1fad3fFmHoPaXAPhm/DJyMcVCwZA=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/linode/linode" {
+  version     = "1.25.2"
+  constraints = "~> 1.25.0"
+  hashes = [
+    "h1:nz4lInCsnZfUeCSKoPsh3oRqyt/RoYOEhGqwvTbkDi8=",
+    "zh:2dda53e1bdf5822d69eef381686af870b3db6c85a5f955392ef8616ffb6da10c",
+    "zh:356b45396ebcbf965a5d3ac1e3e803832e5b7be36046eca74313963637e71372",
+    "zh:377f424936b91a14f47d2b6ebbd7ecfdcff39ab58fe76b1800cb8d267c6c1e00",
+    "zh:40ba9fe8b228adc5a648a85ad5fb37232f67324066d939573e67df109c415f21",
+    "zh:5e39446c7f7c623f6d071a73ca352217b96da47a5605772c2bfed34f68038378",
+    "zh:641a39a30ce6fbcf0e87ba9e32b65cc5ad7d45089d3ab9bc88f9480bb28f0107",
+    "zh:9fa4983fa8693a1a6aefe6bcdf7fe08248b8e28c1cb1fb8e784fccb5a52dafbc",
+    "zh:abf18db180b9a092256e83cba2313f595e9a5bfbc3c04d920e5593cafcfd466d",
+    "zh:b94c6d1ef228abad88fb007b8b20b98d1fd85359cc03ef7ca02fa2e24afc4bf5",
+    "zh:c1de155561187e3a3ad40556feffc12882839332672c0ce1e4fe80c1e2ad0327",
+    "zh:e1230eb0562a5c637781af8d8f9cf356f3834762e982171c955e6ece1c002129",
+    "zh:e1750fefcf2a24339697045b48acb5e0397f3726f5003a284e3e7402463bb405",
+    "zh:e29d432fedbf5abb00d7653815e08a35227242bdf72b6bc0e526597431771053",
+    "zh:f0ca956a985d4dfe4e39fb5bb03130c9a55ea95d2e51c5788f7352b1e61000f0",
+  ]
+}
+
+provider "registry.terraform.io/ojford/wireguard" {
+  version     = "0.1.3"
+  constraints = "~> 0.1.3"
+  hashes = [
+    "h1:tLwoMLiWsjpvS+83Ee270mj1gf7ivZPYCghWpBD4VqE=",
+    "zh:00b01809ab0336f2643a1e2f97c85d5fc4539fff5561c24ab4d195f6d4e5d4c6",
+    "zh:026abd9aed1282ba237f18a7c1742c8e84a9ad61bf178cd6a6568214505c2d52",
+    "zh:1ff8b888c003b7419ed087ab73c4202a98fa9ee5c3e7c8c3b67982087d41282a",
+    "zh:3d9004bddd95d077e709570bf95f3f6db70802e93aaaab37bef2a4d68e3abb33",
+    "zh:504b59047f6f1e3c6a71290a8c0bd971042cd841cee5539923f0937a5651966e",
+    "zh:680f76db52831542e94c7245499318103fcd1b81fc0e75b94d687e2c526ee705",
+    "zh:8134a75fd80af0bb7808afee665ca943d943fe9e0e5257e932faa97a05e01e41",
+    "zh:95ed0816db3847901ae2cfbbf26ace3fe2e4e8a4e83be0f35cd8e4a875fce219",
+    "zh:9f9cb03721ed6078306389ef8600d2569f0b631f25f0bf9622321df034a4f881",
+    "zh:b4deceba9b66fd80bf43d2b3596a0a3f7f55a607bd9d8cfa9cf308684e25edd2",
+    "zh:c1f82b778882d197ebfa9e43e6f8398f2f55fc55eb01931f83ac4df4c7f33f80",
+    "zh:c65872549d9cd4de4854ecf3eb5a51c9d081c557cd6d3a6fb3335758257e76b0",
+  ]
+}

--- a/terraform/linode/README.md
+++ b/terraform/linode/README.md
@@ -1,15 +1,18 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_linode"></a> [linode](#requirement\_linode) | ~> 1.25.0 |
+| <a name="requirement_wireguard"></a> [wireguard](#requirement\_wireguard) | ~> 0.1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_http"></a> [http](#provider\_http) | n/a |
-| <a name="provider_linode"></a> [linode](#provider\_linode) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_wireguard"></a> [wireguard](#provider\_wireguard) | n/a |
+| <a name="provider_http"></a> [http](#provider\_http) | 2.1.0 |
+| <a name="provider_linode"></a> [linode](#provider\_linode) | 1.25.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_wireguard"></a> [wireguard](#provider\_wireguard) | 0.1.3 |
 
 ## Modules
 

--- a/terraform/linode/main.tf
+++ b/terraform/linode/main.tf
@@ -7,10 +7,12 @@ provider "wireguard" {}
 terraform {
   required_providers {
     linode = {
-      source = "linode/linode"
+      source  = "linode/linode"
+      version = "~> 1.25.0"
     }
     wireguard = {
-      source = "OJFord/wireguard"
+      source  = "OJFord/wireguard"
+      version = "~> 0.1.3"
     }
   }
 }


### PR DESCRIPTION
The latest version of the wireguard terraform has marked the wireguard data source as a sensitive attrribute making it impossible to output the config, instead having to pull the state to view it. Pinning the provider will solve this. This was in provider version 0.2.0 released 12 days ago

see https://github.com/OJFord/terraform-provider-wireguard/commit/e629de6b59922f640ec4bb62d3020ccabffffab9

and error

<img width="695" alt="Screen Shot 2022-02-15 at 8 59 19 PM" src="https://user-images.githubusercontent.com/34245618/154182113-61cf2a3c-b05e-4495-8acb-71ca27f30d65.png">

